### PR TITLE
refactor: encode multisend `.as_transaction` without making a call

### DIFF
--- a/ape_safe/multisend.py
+++ b/ape_safe/multisend.py
@@ -224,4 +224,10 @@ class MultiSend(ManagerAccessMixin):
             :class:`~ape.api.transactions.TransactionAPI`
         """
         self._validate_calls(**txn_kwargs)
-        return self.handler.as_transaction(b"".join(self.encoded_calls), **txn_kwargs)
+        # NOTE: Will fail using `self.handler.as_transaction` because handler
+        #       expects to be called only via delegatecall
+        return self.network_manager.ecosystem.create_transaction(
+            receiver=self.handler.contract.address,
+            data=self.handler.encode_input(b"".join(self.encoded_calls)),
+            **txn_kwargs,
+        )


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
