### PR TITLE
feat: impersonate safe [APE-873]

### DIFF
--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -148,7 +148,8 @@ class SafeAccount(AccountAPI):
     @property
     def local_signers(self) -> List[AccountAPI]:
         # NOTE: Is not ordered by signing order
-        # TODO: Use config to skip any local signers
+        # TODO: Skip per user config
+        # TODO: Order per user config
         return list(
             self.account_manager[address]
             for address in self.signers
@@ -315,6 +316,7 @@ class SafeAccount(AccountAPI):
 
         # Garner either M or M - 1 signatures, depending on if we are submitting
         # and whether the submitter is also a signer (both must be true to submit M - 1).
+        # NOTE: Will skip or reorder signers based on config
         available_signers = iter(self.local_signers)
 
         # If number of signatures required not specified, figure out how many are needed
@@ -329,7 +331,7 @@ class SafeAccount(AccountAPI):
                 # Not submitting, or submitter isn't a signer, so we need all confirmations
                 signatures_required = self.confirmations_required
 
-        # Allow bypassing any specified signers
+        # Allow bypassing any specified signers (above and beyond user config)
         if skip:
             skip_addresses = [self.conversion_manager.convert(a, AddressType) for a in skip]
 

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -243,10 +243,14 @@ class SafeAccount(AccountAPI):
             signatures[signer_address] = self._preapproved_signature(signer_address)
 
         # NOTE: Could raise a `SafeContractError`
+        safe_tx_and_call_kwargs["sender"] = safe_tx_and_call_kwargs.get(
+            "submitter",
+            impersonated_signer,  # NOTE: Use whatever the last signer was if no `submitter`
+        )
         return self.contract.execTransaction(
             *safe_tx_exec_args[:-1],  # NOTE: Skip nonce
             self._encode_signatures(signatures),
-            sender=impersonated_sender,
+            **safe_tx_and_call_kwargs,
         )
 
     @handle_safe_logic_error()

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -15,7 +15,7 @@ from eip712.common import create_safe_tx_def
 from eth_utils import to_bytes, to_int
 
 from .client import SafeClient, SafeTx
-from .exceptions import NoLocalSigners, NotEnoughSignatures, SafeLogicError
+from .exceptions import NoLocalSigners, NotASigner, NotEnoughSignatures, SafeLogicError
 
 
 class AccountContainer(AccountContainerAPI):
@@ -196,7 +196,7 @@ class SafeAccount(AccountAPI):
         signer_address: AddressType = self.conversion_manager.convert(signer, AddressType)
         signers = self.contract.getOwners()  # NOTE: Use contract version to ensure correctness
         if signer_address not in signers:
-            raise  # not a signer
+            raise NotASigner(signer_address)
 
         index = signers.index(signer_address)
         if index > 0:

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -211,10 +211,15 @@ class SafeAccount(AccountAPI):
             )
         )
 
-    def _impersonated_call(self, txn: TransactionAPI, **safe_tx_kwargs) -> ReceiptAPI:
-        safe_tx = self.create_safe_tx(txn, **safe_tx_kwargs)
-        safe_tx_exec_args = list(safe_tx._body_["message"].values())
+    def _safe_tx_exec_args(self, safe_tx: SafeTx) -> List:
+        return list(safe_tx._body_["message"].values())
+
+    @handle_safe_logic_error()
+    def _impersonated_call(self, txn: TransactionAPI, **safe_tx_and_call_kwargs) -> ReceiptAPI:
+        safe_tx = self.create_safe_tx(txn, **safe_tx_and_call_kwargs)
+        safe_tx_exec_args = self._safe_tx_exec_args(safe_tx)
         signatures = {}
+
         # Bypass signature collection logic and attempt to submit by impersonation
         # NOTE: Only works for fork and local networks
         # TODO: Once it's a bit easier to set storage slots natively, use that to impersonate

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -208,7 +208,18 @@ class SafeAccount(AccountAPI):
         # NOTE: Need to override `AccountAPI` behavior for balance checks
         return self.provider.prepare_transaction(txn)
 
-    def call(self, txn: TransactionAPI, **call_kwargs) -> ReceiptAPI:  # type: ignore[override]
+    def call(  # type: ignore[override]
+        self,
+        txn: TransactionAPI,
+        impersonate: bool = False,
+        **call_kwargs,
+    ) -> ReceiptAPI:
+        if impersonate:
+            # Bypass signature collection logic and attempt to submit by impersonation
+            # NOTE: Only works for fork and local networks
+            impersonated_account = self.account_manager.test_accounts[self.address]
+            return impersonated_account.call(txn)
+
         # NOTE: Override just to produce a more specific exception with better error message
         try:
             return super().call(txn, **call_kwargs)

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -394,7 +394,7 @@ class SafeAccount(AccountAPI):
 
         elif submit:
             # NOTE: User wanted to submit transaction, but we can't, so don't publish to API
-            raise NotEnoughSignatures(self.confirmations_required, len(sigs_by_signer))
+            raise NotEnoughSignatures(signatures_required, len(sigs_by_signer))
 
         elif submitter and submitter.address in self.signers:
             # Not enough signatures were gathered to submit, but submitter also didn't sign yet,

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -237,7 +237,7 @@ class SafeAccount(AccountAPI):
         # NOTE: Only works for fork and local networks
         # TODO: Once it's a bit easier to set storage slots natively, use that to impersonate
         safe_tx_hash = self.contract.getTransactionHash(*safe_tx_exec_args)
-        for signer_address in self.signers[: self.confirmations_required - 1]:
+        for signer_address in self.signers[: self.confirmations_required]:
             impersonated_signer = self.account_manager.test_accounts[signer_address]
             self.contract.approveHash(safe_tx_hash, sender=impersonated_signer)
             signatures[signer_address] = self._preapproved_signature(signer_address)

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -370,12 +370,7 @@ class SafeAccount(AccountAPI):
                 sigs_by_signer[submitter.address] = self._preapproved_signature(submitter)
 
             # Inherit gas args from safe_tx, if set
-            # NOTE: 0 is a sentinel value for Safe
-            gas_args = {
-                "gas_limit": (
-                    3 * safe_tx.safeTxGas // 2 if safe_tx.safeTxGas > 0 else txn.gas_limit
-                )
-            }
+            gas_args = {"gas_limit": txn.gas_limit}
 
             if txn.type == TransactionType.STATIC:
                 gas_args["gas_price"] = txn.gas_price  # type: ignore[attr-defined]

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -15,7 +15,7 @@ from eip712.common import create_safe_tx_def
 from eth_utils import to_bytes, to_int
 
 from .client import SafeClient, SafeTx
-from .exceptions import NotEnoughSignatures, SafeLogicError
+from .exceptions import NoLocalSigners, NotEnoughSignatures, SafeLogicError
 
 
 class AccountContainer(AccountContainerAPI):
@@ -287,6 +287,9 @@ class SafeAccount(AccountAPI):
 
         else:
             if not submitter:
+                if len(self.local_signers) == 0:
+                    raise NoLocalSigners()
+
                 sender = self.local_signers[0]
 
             elif isinstance(submitter, AccountAPI):

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -148,6 +148,7 @@ class SafeAccount(AccountAPI):
 
     @property
     def local_signers(self) -> List[AccountAPI]:
+        # NOTE: Is not ordered by signing order
         # TODO: Use config to skip any local signers
         return list(
             self.account_manager[address]
@@ -382,7 +383,7 @@ class SafeAccount(AccountAPI):
                 nonce=sender.nonce,  # TODO: Why do we need this?
                 **gas_args,
             )
-            return sender.sign_transaction(exec_transaction)
+            return sender.sign_transaction(exec_transaction, **signer_options)
 
         elif submit:
             # NOTE: User wanted to submit transaction, but we can't, so don't publish to API

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -202,8 +202,13 @@ class SafeAccount(AccountAPI):
 
     def _encode_signatures(self, signatures: Dict[AddressType, MessageSignature]) -> HexBytes:
         # NOTE: Must order signatures in ascending order of signer address (converted to int)
+        def addr_to_int(a: AddressType) -> int:
+            return to_int(hexstr=a)
+
         return HexBytes(
-            b"".join(signatures[signer].encode_rsv() for signer in sorted(signatures, key=to_int))
+            b"".join(
+                signatures[signer].encode_rsv() for signer in sorted(signatures, key=addr_to_int)
+            )
         )
 
     def _impersonated_call(self, txn: TransactionAPI, **safe_tx_kwargs) -> ReceiptAPI:

--- a/ape_safe/exceptions.py
+++ b/ape_safe/exceptions.py
@@ -1,8 +1,14 @@
 from ape.exceptions import ApeException, ContractLogicError, SignatureError
+from ape.types import AddressType
 
 
 class ApeSafeException(ApeException):
     pass
+
+
+class NotASigner(ApeSafeException):
+    def __init__(self, signer: AddressType):
+        super().__init__(f"{signer} is not a valid signer.")
 
 
 class NoLocalSigners(ApeSafeException, SignatureError):

--- a/ape_safe/exceptions.py
+++ b/ape_safe/exceptions.py
@@ -13,7 +13,7 @@ class NoLocalSigners(ApeSafeException, SignatureError):
 class NotEnoughSignatures(ApeSafeException, SignatureError):
     def __init__(self, expected: int, actual: int):
         super().__init__(
-            f"Not enough signatures, need {expected - actual} more! Bypass this behavior"
+            f"Not enough signatures, {expected - actual} more are needed. Bypass this behavior"
             " and publish to Safe API by adding 'submit_transaction=False' to your call."
         )
 

--- a/ape_safe/exceptions.py
+++ b/ape_safe/exceptions.py
@@ -1,16 +1,16 @@
-from ape.exceptions import ApeException, ContractLogicError
+from ape.exceptions import ApeException, ContractLogicError, SignatureError
 
 
 class ApeSafeException(ApeException):
     pass
 
 
-class NoLocalSigners(ApeSafeException):
+class NoLocalSigners(ApeSafeException, SignatureError):
     def __init__(self):
         super().__init__("No local signers available, try resubmitting with `submitter=` kwarg.")
 
 
-class NotEnoughSignatures(ApeSafeException):
+class NotEnoughSignatures(ApeSafeException, SignatureError):
     def __init__(self, expected: int, actual: int):
         super().__init__(
             f"Not enough signatures, need {expected - actual} more! Bypass this behavior"

--- a/ape_safe/exceptions.py
+++ b/ape_safe/exceptions.py
@@ -5,6 +5,11 @@ class ApeSafeException(ApeException):
     pass
 
 
+class NoLocalSigners(ApeSafeException):
+    def __init__(self):
+        super().__init__("No local signers available, try resubmitting with `submitter=` kwarg.")
+
+
 class NotEnoughSignatures(ApeSafeException):
     def __init__(self, expected: int, actual: int):
         super().__init__(

--- a/ape_safe/exceptions.py
+++ b/ape_safe/exceptions.py
@@ -1,3 +1,6 @@
+from contextlib import ContextDecorator
+from typing import Type
+
 from ape.exceptions import ApeException, ContractLogicError, SignatureError
 from ape.types import AddressType
 
@@ -60,6 +63,22 @@ SAFE_ERROR_CODES = {
 class SafeLogicError(ApeSafeException, ContractLogicError):
     def __init__(self, error_code: str):
         super().__init__(f"{SAFE_ERROR_CODES[error_code]} ({error_code})")
+
+
+class handle_safe_logic_error(ContextDecorator):
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type: Type[BaseException], exc: BaseException, tb):
+        if (
+            isinstance(exc, ContractLogicError)  # NOTE: Just for mypy
+            and exc_type == ContractLogicError
+            and exc.message.startswith("GS")
+            and exc.message in SAFE_ERROR_CODES
+        ):
+            raise SafeLogicError(exc.message) from exc
+
+        # NOTE: Will raise `exc` by default because we did not return anything
 
 
 class MulticallException(ApeSafeException):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,9 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]
+# NOTE: can't use xdist
 addopts = """
-    -n auto
+    -n 0
     --cov-branch
     --cov-report term
     --cov-report html

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     url="https://github.com/banteg/ape-safe",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.7,<0.7.0",
+        "eth-ape>=0.6.11,<0.7.0",
         "eip712>=0.2.0,<0.3.0",
     ],
     entry_points={

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -18,7 +18,7 @@ def test_swap_owner(safe, accounts, OWNERS):
 
     # TODO: Remove `gas_limit` by allowing forking to compute gas limit
     receipt = safe.contract.swapOwner(
-        prev_owner, old_owner, new_owner, sender=safe, gas_limit=200_000, safeTxGas=195_000
+        prev_owner, old_owner, new_owner, sender=safe, gas_limit=200_000
     )
 
     assert not receipt.events.filter(safe.contract.ExecutionFailure)
@@ -36,7 +36,7 @@ def test_add_owner(safe, accounts, OWNERS):
 
     # TODO: Remove `gas_limit` by allowing forking to compute gas limit
     receipt = safe.contract.addOwnerWithThreshold(
-        new_owner, safe.confirmations_required, sender=safe, gas_limit=200_000, safeTxGas=195_000
+        new_owner, safe.confirmations_required, sender=safe, gas_limit=200_000
     )
 
     assert not receipt.events.filter(safe.contract.ExecutionFailure)
@@ -61,7 +61,6 @@ def test_remove_owner(safe, OWNERS):
         max(len(OWNERS) - 1, safe.confirmations_required - 1),
         sender=safe,
         gas_limit=200_000,
-        safeTxGas=195_000,
     )
 
     # TODO: Add fucntionality to ContractEvent such that this can work

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -8,8 +8,9 @@ def test_init(safe, OWNERS, THRESHOLD, safe_contract):
     assert safe.next_nonce == 0
 
 
-@pytest.mark.parametrize("impersonate", [False, True])
-def test_swap_owner(safe, accounts, OWNERS, impersonate):
+@pytest.mark.parametrize("mode", ["impersonate", "sign"])
+def test_swap_owner(safe, accounts, OWNERS, mode):
+    impersonate = mode == "impersonate"
     old_owner = safe.signers[0]
     new_owner = accounts[len(OWNERS)]  # replace owner 1 with account N + 1
     assert new_owner.address not in safe.signers
@@ -36,8 +37,9 @@ def test_swap_owner(safe, accounts, OWNERS, impersonate):
     assert new_owner.address in safe.signers
 
 
-@pytest.mark.parametrize("impersonate", [False, True])
-def test_add_owner(safe, accounts, OWNERS, impersonate):
+@pytest.mark.parametrize("mode", ["impersonate", "sign"])
+def test_add_owner(safe, accounts, OWNERS, mode):
+    impersonate = mode == "impersonate"
     new_owner = accounts[len(OWNERS)]  # replace owner 1 with account N + 1
     assert new_owner.address not in safe.signers
 
@@ -57,8 +59,9 @@ def test_add_owner(safe, accounts, OWNERS, impersonate):
     assert new_owner.address in safe.signers
 
 
-@pytest.mark.parametrize("impersonate", [False, True])
-def test_remove_owner(safe, OWNERS, impersonate):
+@pytest.mark.parametrize("mode", ["impersonate", "sign"])
+def test_remove_owner(safe, OWNERS, mode):
+    impersonate = mode == "impersonate"
     if len(OWNERS) == 1:
         pytest.skip("Can't remove the only owner")
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -8,7 +8,8 @@ def test_init(safe, OWNERS, THRESHOLD, safe_contract):
     assert safe.next_nonce == 0
 
 
-def test_swap_owner(safe, accounts, OWNERS):
+@pytest.mark.parametrize("impersonate", [False, True])
+def test_swap_owner(safe, accounts, OWNERS, impersonate):
     old_owner = safe.signers[0]
     new_owner = accounts[len(OWNERS)]  # replace owner 1 with account N + 1
     assert new_owner.address not in safe.signers
@@ -18,7 +19,12 @@ def test_swap_owner(safe, accounts, OWNERS):
 
     # TODO: Remove `gas_limit` by allowing forking to compute gas limit
     receipt = safe.contract.swapOwner(
-        prev_owner, old_owner, new_owner, sender=safe, gas_limit=200_000
+        prev_owner,
+        old_owner,
+        new_owner,
+        sender=safe,
+        gas_limit=200_000,
+        impersonate=impersonate,
     )
 
     assert not receipt.events.filter(safe.contract.ExecutionFailure)
@@ -30,13 +36,18 @@ def test_swap_owner(safe, accounts, OWNERS):
     assert new_owner.address in safe.signers
 
 
-def test_add_owner(safe, accounts, OWNERS):
+@pytest.mark.parametrize("impersonate", [False, True])
+def test_add_owner(safe, accounts, OWNERS, impersonate):
     new_owner = accounts[len(OWNERS)]  # replace owner 1 with account N + 1
     assert new_owner.address not in safe.signers
 
     # TODO: Remove `gas_limit` by allowing forking to compute gas limit
     receipt = safe.contract.addOwnerWithThreshold(
-        new_owner, safe.confirmations_required, sender=safe, gas_limit=200_000
+        new_owner,
+        safe.confirmations_required,
+        sender=safe,
+        gas_limit=200_000,
+        impersonate=impersonate,
     )
 
     assert not receipt.events.filter(safe.contract.ExecutionFailure)
@@ -46,7 +57,8 @@ def test_add_owner(safe, accounts, OWNERS):
     assert new_owner.address in safe.signers
 
 
-def test_remove_owner(safe, OWNERS):
+@pytest.mark.parametrize("impersonate", [False, True])
+def test_remove_owner(safe, OWNERS, impersonate):
     if len(OWNERS) == 1:
         pytest.skip("Can't remove the only owner")
 
@@ -61,6 +73,7 @@ def test_remove_owner(safe, OWNERS):
         max(len(OWNERS) - 1, safe.confirmations_required - 1),
         sender=safe,
         gas_limit=200_000,
+        impersonate=impersonate,
     )
 
     # TODO: Add fucntionality to ContractEvent such that this can work

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -24,7 +24,6 @@ def test_swap_owner(safe, accounts, OWNERS, mode):
         old_owner,
         new_owner,
         sender=safe,
-        gas_limit=200_000,
         impersonate=impersonate,
     )
 
@@ -48,7 +47,6 @@ def test_add_owner(safe, accounts, OWNERS, mode):
         new_owner,
         safe.confirmations_required,
         sender=safe,
-        gas_limit=200_000,
         impersonate=impersonate,
     )
 
@@ -75,7 +73,6 @@ def test_remove_owner(safe, OWNERS, mode):
         # Can't set the threshold to zero or more than the number of owners after removal
         max(len(OWNERS) - 1, safe.confirmations_required - 1),
         sender=safe,
-        gas_limit=200_000,
         impersonate=impersonate,
     )
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -17,7 +17,6 @@ def test_swap_owner(safe, accounts, OWNERS):
     prev_owner = safe.compute_prev_signer(old_owner)
 
     # TODO: Remove `gas_limit` by allowing forking to compute gas limit
-    # TODO: Figure out why `sender=safe` uses impersonated accounts
     receipt = safe.contract.swapOwner(
         prev_owner, old_owner, new_owner, sender=safe, gas_limit=200_000, safeTxGas=195_000
     )
@@ -36,7 +35,6 @@ def test_add_owner(safe, accounts, OWNERS):
     assert new_owner.address not in safe.signers
 
     # TODO: Remove `gas_limit` by allowing forking to compute gas limit
-    # TODO: Figure out why `sender=safe` uses impersonated accounts
     receipt = safe.contract.addOwnerWithThreshold(
         new_owner, safe.confirmations_required, sender=safe, gas_limit=200_000, safeTxGas=195_000
     )
@@ -56,7 +54,6 @@ def test_remove_owner(safe, OWNERS):
 
     prev_owner = safe.compute_prev_signer(old_owner)
     # TODO: Remove `gas_limit` by allowing forking to compute gas limit
-    # TODO: Figure out why `sender=safe` uses impersonated accounts
     receipt = safe.contract.removeOwner(
         prev_owner,
         old_owner,


### PR DESCRIPTION
### What I did

Adds a convenient way to create a transaction executed directly by the Safe for providers that support impersonated accounts

Example:
```py
receipt = contract.myMethod(..., sender=safe, impersonate=True)
# can use the receipt for any other purposes e.g. `receipt.show_trace()`
```

A great way to use this is in temporary fork e.g.:
```py
with networks.fork():
    receipt = contract.myMethod(..., sender=safe, impersonate=True)
    receipt.show_trace()
    ...  # can validate side effects on the fork
```

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
