### PR TITLE
feat: restrict to test accounts in local networks [APE-1377]

### DIFF
--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -187,7 +187,7 @@ class SafeAccount(AccountAPI):
             container = self.account_manager
 
         return list(
-            container[address] for address in self.signers if address in self.account_manager
+            container[address] for address in self.signers if address in container
         )
 
     def get_signatures(

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -186,9 +186,7 @@ class SafeAccount(AccountAPI):
         else:
             container = self.account_manager
 
-        return list(
-            container[address] for address in self.signers if address in container
-        )
+        return list(container[address] for address in self.signers if address in container)
 
     def get_signatures(
         self,

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -177,15 +177,17 @@ class SafeAccount(AccountAPI):
         # NOTE: Is not ordered by signing order
         # TODO: Skip per user config
         # TODO: Order per user config
-        if self.network_manager.active_provider and self.provider.network.name == LOCAL_NETWORK_NAME or self.provider.network.name.endswith("-fork"):
+        if (
+            self.network_manager.active_provider
+            and self.provider.network.name == LOCAL_NETWORK_NAME
+            or self.provider.network.name.endswith("-fork")
+        ):
             container = self.account_manager.test_accounts
         else:
             container = self.account_manager
 
         return list(
-            container[address]
-            for address in self.signers
-            if address in self.account_manager
+            container[address] for address in self.signers if address in self.account_manager
         )
 
     def get_signatures(

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -8,6 +8,7 @@ from ape.api.address import BaseAddress
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractInstance
 from ape.logging import logger
+from ape.managers.accounts import AccountManager, TestAccountManager
 from ape.types import AddressType, HexBytes, MessageSignature, SignableMessage
 from ape.utils import ZERO_ADDRESS, cached_property
 from ape_ethereum.transactions import TransactionType
@@ -177,6 +178,7 @@ class SafeAccount(AccountAPI):
         # NOTE: Is not ordered by signing order
         # TODO: Skip per user config
         # TODO: Order per user config
+        container: Union[AccountManager, TestAccountManager]
         if (
             self.network_manager.active_provider
             and self.provider.network.name == LOCAL_NETWORK_NAME

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Type, Union
 
 from ape.api import AccountAPI, AccountContainerAPI, ReceiptAPI, TransactionAPI
 from ape.api.address import BaseAddress
+from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractInstance
 from ape.logging import logger
 from ape.types import AddressType, HexBytes, MessageSignature, SignableMessage
@@ -176,8 +177,13 @@ class SafeAccount(AccountAPI):
         # NOTE: Is not ordered by signing order
         # TODO: Skip per user config
         # TODO: Order per user config
+        if self.network_manager.active_provider and self.provider.network.name == LOCAL_NETWORK_NAME or self.provider.network.name.endswith("-fork"):
+            container = self.account_manager.test_accounts
+        else:
+            container = self.account_manager
+
         return list(
-            self.account_manager[address]
+            container[address]
             for address in self.signers
             if address in self.account_manager
         )


### PR DESCRIPTION
### What I did

I was having a bug where it would use keyfile accounts because of the address look-up, and that caused unexpected stdin to happen during tests. To alleviate, I made it use test accounts for local networks.

### How I did it

change net first and restrict if needed

### How to verify it

tests work localloy now

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
