### PR TITLE
fix: use api to set confirmations on the tx after adding more

### DIFF
--- a/ape_safe/_cli/pending.py
+++ b/ape_safe/_cli/pending.py
@@ -191,7 +191,6 @@ def approve(cli_ctx: SafeCliContext, safe, txn_ids, execute):
 
         safe_tx = safe.create_safe_tx(**txn.model_dump(by_alias=True, mode="json"))
         num_confirmations = len(txn.confirmations)
-        signatures_added = {}
 
         if num_confirmations < safe.confirmations_required:
             signatures_added = safe.add_signatures(safe_tx, confirmations=txn.confirmations)
@@ -216,7 +215,8 @@ def approve(cli_ctx: SafeCliContext, safe, txn_ids, execute):
                 submitter = safe.select_signer(for_="submitter")
 
         if submitter:
-            txn.confirmations = {**txn.confirmations, **signatures_added}
+            safe_tx_hash = get_safe_tx_hash(safe_tx)
+            txn.confirmations = safe.client.get_confirmations(safe_tx_hash)
             _execute(safe, txn, submitter)
 
     # If any txn_ids remain, they were not handled.

--- a/ape_safe/client/mock.py
+++ b/ape_safe/client/mock.py
@@ -62,7 +62,9 @@ class MockSafeClient(BaseSafeClient, ManagerAccessMixin):
         self,
     ) -> Iterator[SafeApiTxData]:
         for nonce in sorted(self.transactions_by_nonce.keys(), reverse=True):
-            yield from map(self.transactions.get, self.transactions_by_nonce[nonce])
+            for tx in map(self.transactions.get, self.transactions_by_nonce[nonce]):
+                if tx:
+                    yield tx
 
     def get_confirmations(self, safe_tx_hash: SafeTxID) -> Iterator[SafeTxConfirmation]:
         tx_hash = cast(SafeTxID, HexBytes(safe_tx_hash).hex())


### PR DESCRIPTION
### What I did

this ensures they are right and doesnt require anything weird

fixes: #35 

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
