### PR TITLE
refactor(API): add a user agent

### DIFF
--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from functools import reduce
 from typing import Dict, Iterator, Optional, Union, cast
@@ -27,7 +28,10 @@ from ape_safe.exceptions import (
 from ape_safe.utils import get_safe_tx_hash, order_by_signer
 
 APE_SAFE_VERSION = get_package_version(__name__)
-ORIGIN = f"Ape-Safe/{APE_SAFE_VERSION} ({USER_AGENT})"
+APE_SAFE_USER_AGENT = f"Ape-Safe/{APE_SAFE_VERSION} {USER_AGENT}"
+# NOTE: Origin must be a string, but can be json that contains url & name fields
+ORIGIN = json.dumps(dict(url="https://apeworx.io", name="Ape Safe", ua=APE_SAFE_USER_AGENT))
+assert len(ORIGIN) <= 200  # NOTE: Must be less than 200 chars
 
 TRANSACTION_SERVICE_URL = {
     # NOTE: If URLs need to be updated, a list of available service URLs can be found at

--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -3,6 +3,7 @@ from functools import reduce
 from typing import Dict, Iterator, Optional, Union, cast
 
 from ape.types import AddressType, HexBytes, MessageSignature
+from ape.utils.misc import USER_AGENT, get_package_version
 from eip712.common import SafeTxV1, SafeTxV2
 
 from ape_safe.client.base import BaseSafeClient
@@ -24,6 +25,9 @@ from ape_safe.exceptions import (
     MultisigTransactionNotFoundError,
 )
 from ape_safe.utils import get_safe_tx_hash, order_by_signer
+
+APE_SAFE_VERSION = get_package_version(__name__)
+ORIGIN = f"Ape-Safe/{APE_SAFE_VERSION} ({USER_AGENT})"
 
 TRANSACTION_SERVICE_URL = {
     # NOTE: If URLs need to be updated, a list of available service URLs can be found at
@@ -118,7 +122,7 @@ class SafeClient(BaseSafeClient):
                 b"",
             )
         )
-        post_dict: Dict = {"signature": signature.hex()}
+        post_dict: Dict = {"signature": signature.hex(), "origin": ORIGIN}
 
         for key, value in tx_data.model_dump(by_alias=True, mode="json").items():
             if isinstance(value, HexBytes):


### PR DESCRIPTION
### What I did

Noticed in the Safe API transaction service code that a User Agent string is appended to the transaction request when you make a transaction, so I added it

### How I did it

Leverage Ape core's user agent string, as well as do a little researching on how it is supposed to be done

### How to verify it

Make a transaction on a testnet safe

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
