### PR TITLE
refactor: remove goerli

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -38,9 +38,6 @@ foundry:
         mainnet:
           upstream_provider: alchemy
           block_number: 15776634
-        goerli:
-          upstream_provider: alchemy
-          block_number: 7849922
         sepolia:
           upstream_provider: alchemy
           block_number: 3091950

--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -30,7 +30,6 @@ TRANSACTION_SERVICE_URL = {
     # https://docs.safe.global/safe-core-api/available-services.
     # NOTE: There should be no trailing slashes at the end of the URL.
     1: "https://safe-transaction-mainnet.safe.global",
-    5: "https://safe-transaction-goerli.safe.global",
     10: "https://safe-transaction-optimism.safe.global",
     56: "https://safe-transaction-bsc.safe.global",
     100: "https://safe-transaction-gnosis-chain.safe.global",


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
