### PR TITLE
fix: safe tx gas price should be zero

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -14,8 +14,8 @@ ethereum:
 
 dependencies:
   - name: safe-contracts
-    npm: "@gnosis.pm/safe-contracts"
-    version: 1.3.0
+    github: safe-global/safe-smart-account
+    version: v1.3.0
     config_override:
       compile:
         exclude:

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -348,14 +348,6 @@ class SafeAccount(AccountAPI):
         Returns:
             :class:`~ape_safe.client.SafeTx`: The Safe Transaction to be used.
         """
-        gas_price = safe_tx_kwargs.get(
-            "gas_price", safe_tx_kwargs.get("gasPrice", safe_tx_kwargs.get("gas"))
-        )
-        if gas_price is None and isinstance(txn, StaticFeeTransaction):
-            gas_price = txn.gas_price or 0
-        elif gas_price is None:
-            gas_price = 0
-
         safe_tx = {
             "to": txn.receiver if txn else self.address,  # Self-call, e.g. rejection
             "value": txn.value if txn else 0,
@@ -363,7 +355,7 @@ class SafeAccount(AccountAPI):
             "nonce": self.new_nonce if txn is None or txn.nonce is None else txn.nonce,
             "operation": 0,
             "safeTxGas": 0,
-            "gasPrice": gas_price,
+            "gasPrice": 0,
             "gasToken": ZERO_ADDRESS,
             "refundReceiver": ZERO_ADDRESS,
         }

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -14,7 +14,7 @@ from ape.logging import logger
 from ape.managers.accounts import AccountManager, TestAccountManager
 from ape.types import AddressType, HexBytes, MessageSignature
 from ape.utils import ZERO_ADDRESS, cached_property
-from ape_ethereum.transactions import StaticFeeTransaction, TransactionType
+from ape_ethereum.transactions import TransactionType
 from eip712.common import create_safe_tx_def
 from eth_account.messages import encode_defunct
 from eth_utils import keccak, to_bytes, to_int

--- a/tests/integration/test_pending_cli.py
+++ b/tests/integration/test_pending_cli.py
@@ -37,28 +37,6 @@ def test_propose(runner, cli, one_safe, receiver, chain):
     assert one_safe.next_nonce == nonce_at_start
 
 
-def test_propose_with_gas_price(runner, cli, one_safe, receiver, chain):
-    cmd = (
-        "pending",
-        "propose",
-        "--to",
-        receiver.address,
-        "--value",
-        "1",
-        "--gas-price",
-        chain.provider.gas_price + 1,
-        "--network",
-        chain.provider.network_choice,
-    )
-    result = runner.invoke(cli, cmd, catch_exceptions=False, input=f"{one_safe.alias}\n")
-    assert result.exit_code == 0
-    safe_tx_hash = result.output.split("Proposed transaction '")[-1].split("'")[0].strip()
-
-    # Verify gas price was used.
-    tx = one_safe.client.transactions[safe_tx_hash]
-    assert tx.gas_price > 0
-
-
 def test_propose_with_sender(runner, cli, one_safe, receiver, chain, foundry):
     # First, fund the safe so the tx does not fail.
     receiver.transfer(one_safe, "1 ETH")


### PR DESCRIPTION
### What I did

gas price has a different meaning in safe transactions. it is used to pay the relayer which is not what we want.

https://github.com/safe-global/safe-smart-account/blob/a9e3385bb38c29d45b3901ff7180b59fcee86ac9/contracts/Safe.sol#L180-L182

fixes inability to execute submitted transactions.

### How I did it

force `gas_price` to zero

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
