### PR TITLE
feat: sign eip-712 message instead of hash

### DIFF
--- a/ape_safe/_cli/pending.py
+++ b/ape_safe/_cli/pending.py
@@ -129,7 +129,7 @@ def propose(cli_ctx, ecosystem, safe, data, gas_price, value, receiver, nonce, s
     )
     safe_tx = safe.create_safe_tx(txn)
     safe_tx_hash = get_safe_tx_hash(safe_tx)
-    signatures = get_signatures(safe_tx_hash, safe.local_signers)
+    signatures = get_signatures(safe_tx, safe.local_signers)
 
     num_confirmations = 0
     submitter = sender if isinstance(sender, AccountAPI) else None

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -16,7 +16,6 @@ from ape.types import AddressType, HexBytes, MessageSignature
 from ape.utils import ZERO_ADDRESS, cached_property
 from ape_ethereum.transactions import StaticFeeTransaction, TransactionType
 from eip712.common import create_safe_tx_def
-from eth_account.messages import encode_defunct
 from eth_utils import keccak, to_bytes, to_int
 from ethpm_types import ContractType
 


### PR DESCRIPTION
see also https://docs.safe.global/advanced/smart-account-signatures

### What I did

sign eip-712 message instead of defunct message.

if you follow the naming in [safe docs](https://docs.safe.global/advanced/smart-account-signatures), i have switched `eth_sign` signature for ecdsa signature.

it has also allowed to remove the method to adjust `v` of the signature.

fixes: #54

### How I did it

replace signing of `safe_tx_hash` with signing of `safe_tx`.

### How to verify it

```python
In [9]: yes.transfer(dev, '1 ether', nonce=1, sender=safe, submit=False)
Signing EIP712 Message
Domain
	Chain ID: 81457
	Contract: 0x...
Message
	to: 0x1a49351bdB4BE48C0009b661765D01ed58E8C2d8
	value: 0
	data: b'\xa9\x05\x9c\xbb\...'
	operation: 0
	safeTxGas: 0
	baseGas: 0
	gasPrice: 0
	gasToken: 0x0000000000000000000000000000000000000000
	refundReceiver: 0x0000000000000000000000000000000000000000
	nonce: 1


Sign:  [y/N]: y
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
