### PR TITLE
chore: move macos image back to latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,9 +59,7 @@ jobs:
 
         strategy:
             matrix:
-                # TODO: Replace with macos-latest when works again.
-                #   https://github.com/actions/setup-python/issues/808
-                os: [ubuntu-latest, macos-12]   # eventually add `windows-latest`
+                os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
                 python-version: ["3.9", "3.10", "3.11", "3.12"]
                 safe-version: ["1.3.0"]
 


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
