### PR TITLE
test: adjust tests to not double-download Safe contracts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,9 @@ def config(project):
     # Ensure we don't persist any .ape data.
     with create_tempdir() as path:
         # First, copy in Safe contracts so we don't download each time.
-        shutil.copytree(cfg.DATA_FOLDER, path)
-        cfg.DATA_FOLDER = path
+        dest = path / "dest"
+        shutil.copytree(cfg.DATA_FOLDER, dest)
+        cfg.DATA_FOLDER = dest
         yield cfg
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,11 +1,11 @@
 import shutil
+from contextlib import contextmanager
 
 import pytest
-from contextlib import contextmanager
+from ape.utils import create_tempdir
 from click.testing import CliRunner
 
 from ape_safe._cli import cli as CLI
-from ape.utils import create_tempdir
 
 
 @pytest.fixture


### PR DESCRIPTION
fixes: https://github.com/ApeWorX/ape/issues/2133

I believe as a result of this PR, tests even in CI run a lot faster.

Add delegates from last week total duration: 12m 35s
This PR total duration: 3m 43s