### PR TITLE
feat(api): self host Safe API

### DIFF
--- a/ape_safe/_cli/__init__.py
+++ b/ape_safe/_cli/__init__.py
@@ -3,6 +3,11 @@ import click
 from ape_safe._cli.pending import pending
 from ape_safe._cli.safe_mgmt import _list, add, all_txns, remove
 
+try:
+    from ape_safe._cli.host_api import host
+except ImportError:
+    host = None  # type: ignore[assignment]
+
 
 @click.group(short_help="Manage Safe accounts and view Safe API data")
 def cli():
@@ -17,3 +22,5 @@ cli.add_command(add)
 cli.add_command(remove)
 cli.add_command(all_txns)
 cli.add_command(pending)
+if host:
+    cli.add_command(host)

--- a/ape_safe/_cli/host_api.py
+++ b/ape_safe/_cli/host_api.py
@@ -1,0 +1,43 @@
+import os
+from typing import Annotated
+
+import click
+import uvicorn
+from ape import accounts
+from ape.cli import ConnectedProviderCommand
+from ape.types import AddressType
+from eth_pydantic_types import Address
+from fastapi import Depends, FastAPI, HTTPException
+
+from ape_safe.accounts import SafeAccount
+from ape_safe.client import MockSafeClient, SafeDetails
+
+app = FastAPI()
+
+
+def get_accounts() -> dict[AddressType, SafeAccount]:
+    safe_account_container = accounts.containers["safe"]
+    for safe in safe_account_container.accounts:
+        safe.client = MockSafeClient(safe.contract)
+    return {a.address: a for a in safe_account_container.accounts}
+
+
+LocalSafeAccounts = Annotated[dict[AddressType, SafeAccount], Depends(get_accounts)]
+
+
+# NOTE: Mimic official Safe API
+@app.get("/api/v1/safes/{address}")
+@app.get("/api/v1/safes/{address}/")
+async def api_v1_get_safe_details(address: Address, safes: LocalSafeAccounts) -> SafeDetails:
+    if not (safe := safes.get(address)):
+        raise HTTPException(status_code=404, detail=f"Safe not found '{address}'.")
+
+    return safe.client.safe_details
+
+
+@click.command(cls=ConnectedProviderCommand)
+@click.option("--port", type=int, default=8000)
+def host(port):
+    """Run a local-only Safe API for aggregating signatures"""
+    os.environ["SAFE_TRANSACTION_SERVICE_URL"] = f"http://localhost:{port}"
+    uvicorn.run(app)

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ extras_require = {
         "IPython",  # Console for interacting
         "ipdb",  # Debugger (Must use `export PYTHONBREAKPOINT=ipdb.set_trace`)
     ],
+    "host": [  # Deps for self-hosting your own Safe API
+        "fastapi[standard]>=0.110",
+    ],
 }
 
 # NOTE: `pip install -e .[dev]` to install package
@@ -45,6 +48,7 @@ extras_require["dev"] = (
     extras_require["test"]
     + extras_require["lint"]
     + extras_require["release"]
+    + extras_require["host"]
     + extras_require["dev"]
 )
 


### PR DESCRIPTION
### What I did

On days like today, it sure would be nice to have a self-host option for when the Safe API service is down. There are also use cases where hosting an (authenticated) Safe API service is more critical, to avoid leaking information prior to publishing a SafeTx. Support both these use cases using `ape safe host` subcommand, and then publish a Docker image people can easily run in case they want to host their own version of the API separately.

fixes: #

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
