### PR TITLE
feat: refactor safe client to use multichain gateway

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,11 @@ jobs:
             pip install .[test]
 
         - name: Run Functional Tests
+          env:
+            APE_SAFE_GATEWAY_API_KEY: ${{ secrets.APE_SAFE_GATEWAY_API_KEY }}
           run: ape test -n 0 tests/functional/ -s --cov -v WARNING
 
         - name: Run Integration Tests
+          env:
+            APE_SAFE_GATEWAY_API_KEY: ${{ secrets.APE_SAFE_GATEWAY_API_KEY }}
           run: ape test -n 0 tests/integration/ -s --cov -v WARNING

--- a/ape_safe/_cli/safe_mgmt.py
+++ b/ape_safe/_cli/safe_mgmt.py
@@ -10,6 +10,7 @@ from ape.exceptions import ChainError, ProviderNotConnectedError
 from eth_typing import ChecksumAddress
 
 from ape_safe._cli.click_ext import SafeCliContext, safe_argument, safe_cli_ctx
+from ape_safe.client import SafeClient
 
 
 @click.command(name="list")
@@ -145,9 +146,8 @@ def all_txns(cli_ctx: SafeCliContext, account, confirmed):
         account = cli_ctx.account_manager.load(account)
 
     address = cli_ctx.conversion_manager.convert(account, AddressType)
-
-    # NOTE: Create a client to support non-local safes.
-    client = cli_ctx.safes.create_client(address)
+    chain_id = cli_ctx.provider.chain_id
+    client = SafeClient(address=address, chain_id=chain_id)
 
     for txn in client.get_transactions(confirmed=confirmed):
         if isinstance(txn, ExecutedTxData):

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -199,12 +199,12 @@ class SafeAccount(AccountAPI):
         return self.account_file_path.stem
 
     @property
-    def account_file(self) -> SafeCacheData:
+    def account_data(self) -> SafeCacheData:
         return SafeCacheData.model_validate_json(self.account_file_path.read_text(encoding="utf-8"))
 
     @property
     def deployed_chain_ids(self) -> list[int]:
-        return self.account_file.deployed_chain_ids
+        return self.account_data.deployed_chain_ids
 
     @cached_property
     def address(self) -> AddressType:
@@ -213,7 +213,7 @@ class SafeAccount(AccountAPI):
         except ProviderNotConnectedError:
             ecosystem = self.network_manager.ethereum
 
-        return ecosystem.decode_address(self.account_file.address)
+        return ecosystem.decode_address(self.account_data.address)
 
     @cached_property
     def contract(self) -> "ContractInstance":

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -169,27 +169,6 @@ class SafeContainer(AccountContainerAPI):
         """
         self._get_path(alias).unlink(missing_ok=True)
 
-    def create_client(self, key: str) -> BaseSafeClient:
-        if key in self.aliases:
-            safe = self.load_account(key)
-            return safe.client
-
-        elif key in self.addresses:
-            account = cast(SafeAccount, self[cast(AddressType, key)])
-            return account.client
-
-        elif key in self.aliases:
-            return self.load_account(key).client
-
-        else:
-            address = self.conversion_manager.convert(key, AddressType)
-            if address in self.addresses:
-                account = cast(SafeAccount, self[cast(AddressType, key)])
-                return account.client
-
-            # Is not locally managed.
-            return SafeClient(address=address, chain_id=self.chain_manager.provider.chain_id)
-
     def _get_path(self, alias: str) -> Path:
         return self.data_folder.joinpath(f"{alias}.json")
 
@@ -222,6 +201,10 @@ class SafeAccount(AccountAPI):
     @property
     def account_file(self) -> SafeCacheData:
         return SafeCacheData.model_validate_json(self.account_file_path.read_text(encoding="utf-8"))
+
+    @property
+    def deployed_chain_ids(self) -> list[int]:
+        return self.account_file.get("deployed_chain_ids", [])
 
     @cached_property
     def address(self) -> AddressType:
@@ -288,34 +271,32 @@ class SafeAccount(AccountAPI):
 
         return self.contract.setGuard(new_guard, **tx_args)
 
+    def get_client(
+        self, chain_id: Optional[int] = None, override_url: Optional[str] = None
+    ) -> BaseSafeClient:
+        if chain_id is None:
+            chain_id = self.provider.chain_id
+
+        if override_url is None:
+            env_override = os.environ.get("SAFE_TRANSACTION_SERVICE_URL")
+            if env_override:
+                override_url = env_override
+
+        if chain_id == 0 or (self.provider.network.is_local and self.provider.chain_id == chain_id):
+            return MockSafeClient(contract=self.contract)
+
+        return SafeClient(address=self.address, chain_id=chain_id, override_url=override_url)
+
     @cached_property
     def client(self) -> BaseSafeClient:
-        chain_id = self.provider.chain_id
-        override_url = os.environ.get("SAFE_TRANSACTION_SERVICE_URL")
-
-        if self.provider.network.is_local:
-            return MockSafeClient(contract=self.contract)
-
-        elif chain_id in self.account_file.deployed_chain_ids:
-            return SafeClient(
-                address=self.address, chain_id=self.provider.chain_id, override_url=override_url
-            )
-
-        elif (
+        if (
             self.provider.network.name.endswith("-fork")
             and isinstance(self.provider.network, ForkedNetworkAPI)
-            and self.provider.network.upstream_chain_id in self.account_file.deployed_chain_ids
+            and self.provider.network.upstream_chain_id in self.deployed_chain_ids
         ):
-            return SafeClient(
-                address=self.address,
-                chain_id=self.provider.network.upstream_chain_id,
-                override_url=override_url,
-            )
+            return self.get_client(chain_id=self.provider.network.upstream_chain_id)
 
-        elif self.provider.network.is_dev:
-            return MockSafeClient(contract=self.contract)
-
-        return SafeClient(address=self.address, chain_id=self.provider.chain_id)
+        return self.get_client()
 
     @property
     def version(self) -> Version:

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -204,7 +204,7 @@ class SafeAccount(AccountAPI):
 
     @property
     def deployed_chain_ids(self) -> list[int]:
-        return self.account_file.get("deployed_chain_ids", [])
+        return self.account_file.deployed_chain_ids
 
     @cached_property
     def address(self) -> AddressType:
@@ -425,6 +425,7 @@ class SafeAccount(AccountAPI):
 
         if submitter is not None and not isinstance(submitter, AccountAPI):
             submitter = self.load_submitter(submitter)
+            assert isinstance(submitter, AccountAPI)  # NOTE: mypy happy
 
         if (
             submitter is not None

--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -683,6 +683,7 @@ class SafeAccount(AccountAPI):
 
         if not isinstance(submitter, AccountAPI):
             submitter = self.load_submitter(submitter)
+            assert isinstance(submitter, AccountAPI)  # NOTE: mypy happy
 
         return submitter.call(txn)
 

--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -78,7 +78,7 @@ class SafeClient(BaseSafeClient):
         Get all transactions from safe, both confirmed and unconfirmed
         """
 
-        url = f"/safes/{self.address}/all-transactions"
+        url = f"/safes/{self.address}/multisig-transactions/raw"
         while url:
             response = self._get(url)
             data = response.json()

--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -40,23 +40,8 @@ APE_SAFE_USER_AGENT = f"Ape-Safe/{APE_SAFE_VERSION} {USER_AGENT}"
 ORIGIN = json.dumps(dict(url="https://apeworx.io", name="Ape Safe", ua=APE_SAFE_USER_AGENT))
 assert len(ORIGIN) <= 200  # NOTE: Must be less than 200 chars
 
-TRANSACTION_SERVICE_URL = {
-    # NOTE: If URLs need to be updated, a list of available service URLs can be found at
-    # https://docs.safe.global/safe-core-api/available-services.
-    # NOTE: There should be no trailing slashes at the end of the URL.
-    1: "https://safe-transaction-mainnet.safe.global",
-    10: "https://safe-transaction-optimism.safe.global",
-    56: "https://safe-transaction-bsc.safe.global",
-    100: "https://safe-transaction-gnosis-chain.safe.global",
-    137: "https://safe-transaction-polygon.safe.global",
-    250: "https://safe-txservice.fantom.network",
-    288: "https://safe-transaction.mainnet.boba.network",
-    8453: "https://safe-transaction-base.safe.global",
-    42161: "https://safe-transaction-arbitrum.safe.global",
-    43114: "https://safe-transaction-avalanche.safe.global",
-    84531: "https://safe-transaction-base-testnet.safe.global",
-    11155111: "https://safe-transaction-sepolia.safe.global",
-}
+# URL for the multichain client gateway
+SAFE_CLIENT_GATEWAY_URL = "https://safe-client.safe.global"
 
 
 class SafeClient(BaseSafeClient):
@@ -67,20 +52,18 @@ class SafeClient(BaseSafeClient):
         chain_id: Optional[int] = None,
     ) -> None:
         self.address = address
+        self.chain_id = chain_id
 
         if override_url:
-            tx_service_url = override_url
-
+            base_url = override_url
+            self.use_client_gateway = False
         elif chain_id:
-            if chain_id not in TRANSACTION_SERVICE_URL:
-                raise ClientUnsupportedChainError(chain_id)
-
-            tx_service_url = TRANSACTION_SERVICE_URL[chain_id]
-
+            base_url = SAFE_CLIENT_GATEWAY_URL
+            self.use_client_gateway = True
         else:
             raise ValueError("Must provide one of chain_id or override_url.")
 
-        super().__init__(tx_service_url)
+        super().__init__(base_url)
 
     @property
     def safe_details(self) -> SafeDetails:

--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -56,7 +56,6 @@ TRANSACTION_SERVICE_URL = {
     43114: "https://safe-transaction-avalanche.safe.global",
     84531: "https://safe-transaction-base-testnet.safe.global",
     11155111: "https://safe-transaction-sepolia.safe.global",
-    81457: "https://transaction.blast-safe.io",
 }
 
 

--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -26,7 +26,6 @@ from ape_safe.client.types import (
 from ape_safe.exceptions import (
     ActionNotPerformedError,
     ClientResponseError,
-    ClientUnsupportedChainError,
     MultisigTransactionNotFoundError,
 )
 from ape_safe.utils import get_safe_tx_hash, order_by_signer

--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -67,7 +67,7 @@ class SafeClient(BaseSafeClient):
 
     @property
     def safe_details(self) -> SafeDetails:
-        response = self._get(f"safes/{self.address}/")
+        response = self._get(f"/safes/{self.address}")
         return SafeDetails.model_validate(response.json())
 
     def get_next_nonce(self) -> int:
@@ -78,7 +78,7 @@ class SafeClient(BaseSafeClient):
         Get all transactions from safe, both confirmed and unconfirmed
         """
 
-        url = f"safes/{self.address}/all-transactions/"
+        url = f"/safes/{self.address}/all-transactions"
         while url:
             response = self._get(url)
             data = response.json()
@@ -97,7 +97,7 @@ class SafeClient(BaseSafeClient):
             url = data.get("next")
 
     def get_confirmations(self, safe_tx_hash: SafeTxID) -> Iterator[SafeTxConfirmation]:
-        url = f"multisig-transactions/{str(safe_tx_hash)}/confirmations/"
+        url = f"/multisig-transactions/{str(safe_tx_hash)}/confirmations"
         while url:
             response = self._get(url)
             data = response.json()
@@ -135,7 +135,7 @@ class SafeClient(BaseSafeClient):
             # Signature handled above.
             post_dict.pop("signatures")
 
-        url = f"safes/{tx_data.safe}/multisig-transactions/"
+        url = f"/safes/{tx_data.safe}/multisig-transactions"
         response = self._post(url, json=post_dict)
         return response
 
@@ -151,7 +151,7 @@ class SafeClient(BaseSafeClient):
             safe_tx_hash = safe_tx_or_hash
 
         safe_tx_hash = cast(SafeTxID, to_hex(HexBytes(safe_tx_hash)))
-        url = f"multisig-transactions/{safe_tx_hash}/confirmations/"
+        url = f"/multisig-transactions/{safe_tx_hash}/confirmations"
         signature = to_hex(
             HexBytes(b"".join([x.encode_rsv() for x in order_by_signer(signatures)]))
         )
@@ -166,7 +166,7 @@ class SafeClient(BaseSafeClient):
     def estimate_gas_cost(
         self, receiver: AddressType, value: int, data: bytes, operation: int = 0
     ) -> Optional[int]:
-        url = f"safes/{self.address}/multisig-transactions/estimations/"
+        url = f"/safes/{self.address}/multisig-transactions/estimations"
         request: dict = {
             "to": receiver,
             "value": value,
@@ -178,7 +178,7 @@ class SafeClient(BaseSafeClient):
         return int(to_hex(HexBytes(gas)), 16)
 
     def get_delegates(self) -> dict["AddressType", list["AddressType"]]:
-        url = "delegates/"
+        url = "/delegates"
         delegates: dict[AddressType, list[AddressType]] = {}
 
         while url:
@@ -209,7 +209,7 @@ class SafeClient(BaseSafeClient):
             "label": label,
             "signature": sig.encode_rsv().hex(),
         }
-        self._post("delegates/", json=payload)
+        self._post("/delegates", json=payload)
 
     def remove_delegate(self, delegate: "AddressType", delegator: "AccountAPI"):
         msg_hash = self.create_delegate_message(delegate)
@@ -222,7 +222,7 @@ class SafeClient(BaseSafeClient):
             "delegator": delegator.address,
             "signature": sig.encode_rsv().hex(),
         }
-        self._delete(f"delegates/{delegate}/", json=payload)
+        self._delete(f"/delegates/{delegate}", json=payload)
 
 
 __all__ = [

--- a/ape_safe/client/base.py
+++ b/ape_safe/client/base.py
@@ -33,8 +33,8 @@ DEFAULT_HEADERS = {
 
 
 class BaseSafeClient(ABC):
-    def __init__(self, transaction_service_url: str):
-        self.transaction_service_url = transaction_service_url
+    def __init__(self, base_url: str):
+        self.base_url = base_url
 
     """Abstract methods"""
 
@@ -160,13 +160,23 @@ class BaseSafeClient(ABC):
         return urllib3.PoolManager(ca_certs=certifi.where())
 
     def _request(self, method: str, url: str, json: Optional[dict] = None, **kwargs) -> "Response":
+        api_version = kwargs.pop("api_version", "v1")
+
         # NOTE: paged requests include full url already
-        if url.startswith(f"{self.transaction_service_url}/api/v1/"):
+        if url.startswith(f"{self.base_url}/"):
             api_url = url
         else:
-            # **WARNING**: The trailing slash in the URL is CRITICAL!
-            # If you remove it, things will not work as expected.
-            api_url = f"{self.transaction_service_url}/api/v1/{url}/"
+            if (
+                hasattr(self, "use_client_gateway")
+                and self.use_client_gateway
+                and hasattr(self, "chain_id")
+            ):
+                # **WARNING**: The trailing slash in the URL is CRITICAL!
+                # If you remove it, things will not work as expected.
+                api_url = f"{self.base_url}/{api_version}/chains/{self.chain_id}/{url}/"
+            else:
+                api_url = f"{self.base_url}/api/v1/{url}/"
+
         do_fail = not kwargs.pop("allow_failure", False)
 
         # Use `or 10` to handle when None is explicit.

--- a/ape_safe/client/base.py
+++ b/ape_safe/client/base.py
@@ -163,19 +163,18 @@ class BaseSafeClient(ABC):
         api_version = kwargs.pop("api_version", "v1")
 
         # NOTE: paged requests include full url already
-        if url.startswith(f"{self.base_url}/"):
+        if url.startswith(self.base_url):
             api_url = url
+
+        elif (
+            hasattr(self, "use_client_gateway")
+            and self.use_client_gateway
+            and hasattr(self, "chain_id")
+        ):
+            api_url = f"{self.base_url}/{api_version}/chains/{self.chain_id}{url}"
+
         else:
-            if (
-                hasattr(self, "use_client_gateway")
-                and self.use_client_gateway
-                and hasattr(self, "chain_id")
-            ):
-                # **WARNING**: The trailing slash in the URL is CRITICAL!
-                # If you remove it, things will not work as expected.
-                api_url = f"{self.base_url}/{api_version}/chains/{self.chain_id}/{url}/"
-            else:
-                api_url = f"{self.base_url}/api/v1/{url}/"
+            api_url = f"{self.base_url}/{api_version}{url}"
 
         do_fail = not kwargs.pop("allow_failure", False)
 

--- a/ape_safe/client/base.py
+++ b/ape_safe/client/base.py
@@ -166,13 +166,6 @@ class BaseSafeClient(ABC):
         if url.startswith(self.base_url):
             api_url = url
 
-        elif (
-            hasattr(self, "use_client_gateway")
-            and self.use_client_gateway
-            and hasattr(self, "chain_id")
-        ):
-            api_url = f"{self.base_url}/{api_version}/chains/{self.chain_id}{url}"
-
         else:
             api_url = f"{self.base_url}/{api_version}{url}"
 

--- a/ape_safe/client/mock.py
+++ b/ape_safe/client/mock.py
@@ -43,7 +43,7 @@ class MockSafeClient(BaseSafeClient, ManagerAccessMixin):
             nonce=self.get_next_nonce(),
             threshold=self.contract.getThreshold(),
             owners=self.contract.getOwners(),
-            implementation=self.contract.masterCopy(),
+            masterCopy=self.contract.masterCopy(),
             modules=self.modules,
             # TODO: Add fallback handler getter
             fallbackHandler=fallback_address,

--- a/ape_safe/client/mock.py
+++ b/ape_safe/client/mock.py
@@ -43,7 +43,7 @@ class MockSafeClient(BaseSafeClient, ManagerAccessMixin):
             nonce=self.get_next_nonce(),
             threshold=self.contract.getThreshold(),
             owners=self.contract.getOwners(),
-            masterCopy=self.contract.masterCopy(),
+            implementation=self.contract.masterCopy(),
             modules=self.modules,
             # TODO: Add fallback handler getter
             fallbackHandler=fallback_address,

--- a/ape_safe/client/types.py
+++ b/ape_safe/client/types.py
@@ -29,7 +29,7 @@ class SafeDetails(BaseModel):
     nonce: int
     threshold: int
     owners: list[Address]
-    master_copy: Address = Field(alias="implementation")
+    master_copy: Address = Field(alias="masterCopy")
     modules: list[Address] = []
     fallback_handler: Address = Field(alias="fallbackHandler")
     guard: AddressType

--- a/ape_safe/client/types.py
+++ b/ape_safe/client/types.py
@@ -131,12 +131,12 @@ class ExecutedTxData(UnexecutedTxData):
     is_executed: bool = Field(alias="isExecuted")
     is_successful: bool = Field(alias="isSuccessful")
     eth_gas_price: int = Field(alias="ethGasPrice")
-    max_fee_per_gas: Optional[int] = Field(alias="maxFeePerGas")
-    max_priority_fee_per_gas: Optional[int] = Field(alias="maxPriorityFeePerGas")
+    max_fee_per_gas: Optional[int] = Field(default=None, alias="maxFeePerGas")
+    max_priority_fee_per_gas: Optional[int] = Field(default=None, alias="maxPriorityFeePerGas")
     gas_used: int = Field(alias="gasUsed")
     fee: int
     origin: str
-    data_decoded: Optional[dict] = Field(alias="dataDecoded")
+    data_decoded: Optional[dict] = Field(default=None, alias="dataDecoded")
 
 
 SafeApiTxData = Union[ExecutedTxData, UnexecutedTxData]

--- a/ape_safe/exceptions.py
+++ b/ape_safe/exceptions.py
@@ -113,12 +113,6 @@ class SafeClientException(ApeSafeException):
     pass
 
 
-class ClientUnsupportedChainError(SafeClientException):
-    def __init__(self, chain_id: int, message: Optional[str] = None):
-        msg = message or f"Unsupported Chain ID '{chain_id}'."
-        super().__init__(msg)
-
-
 class ActionNotPerformedError(SafeClientException):
     def __init__(self, message: str):
         super().__init__(message)

--- a/ape_safe/exceptions.py
+++ b/ape_safe/exceptions.py
@@ -114,8 +114,9 @@ class SafeClientException(ApeSafeException):
 
 
 class ClientUnsupportedChainError(SafeClientException):
-    def __init__(self, chain_id: int):
-        super().__init__(f"Unsupported Chain ID '{chain_id}'.")
+    def __init__(self, chain_id: int, message: Optional[str] = None):
+        msg = message or f"Unsupported Chain ID '{chain_id}'."
+        super().__init__(msg)
 
 
 class ActionNotPerformedError(SafeClientException):

--- a/tests/functional/test_account.py
+++ b/tests/functional/test_account.py
@@ -98,38 +98,15 @@ def test_safe_account_convert(safe):
     assert actual == safe.address
 
 
-def test_deployed_chain_ids(safe):
-    """
-    Test the deployed_chain_ids property.
-    """
-    # The deployed_chain_ids should match what's in the account file
-    assert safe.deployed_chain_ids == safe.account_file.get("deployed_chain_ids", [])
-
-
-def test_get_client(safe, monkeypatch):
+def test_get_client(safe):
     """
     Test getting a client for a specific chain ID.
     """
     # Create a test deployed_chain_ids list
-    test_chain_ids = [1, 10, 100]
-    monkeypatch.setattr(safe, "deployed_chain_ids", test_chain_ids)
+    safe_data = safe.account_data
+    safe_data.deployed_chain_ids = [1, 10, 100]
+    safe.account_file_path.write_text(safe_data.model_dump_json())
 
     # Should work for a specified chain ID
     client = safe.get_client(chain_id=1)
-    assert client.chain_id == 1
-    assert hasattr(client, "use_client_gateway")
-    assert client.use_client_gateway is True
-
-    # Should use current chain if no chain ID is provided
-    current_chain_id = safe.provider.chain_id
-    client = safe.get_client()
-    assert client.chain_id == current_chain_id
-
-    # Should accept override_url
-    client = safe.get_client(override_url="https://example.com")
-    assert not client.use_client_gateway
-
-    # Should accept both chain_id and override_url
-    client = safe.get_client(chain_id=1, override_url="https://example.com")
-    assert client.chain_id == 1
-    assert not client.use_client_gateway
+    assert "/eth/" in client.base_url


### PR DESCRIPTION
## Summary
- Use new gateway URL https://safe-client.safe.global/ instead of network-specific URLs
- Add deployed_chain_ids property to SafeAccount for easier chain access
- Add get_client method with optional chain_id parameter
- Update URL paths to include chain ID for multichain gateway
- Update CLI to use new client interface
- Improve naming and documentation

Fixes #56

## Test plan
- Run the tests
- Try to access a Safe on multiple chains