### PR TITLE
fix(Deps): pin sphinx-ape to latest release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
         "mdformat-pyproject>=0.0.2",  # Allows configuring in pyproject.toml
     ],
     "docs": [
-        "sphinx-ape @ git+https://github.com/ApeWorX/sphinx-ape.git",
+        "sphinx-ape>=0.1,<1",  # Use dependencies of our custom docs plugin
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools>=75.6.0",  # Installation tool


### PR DESCRIPTION
### What I did

v0.8.13 failed to publish because we have a pinned dep to a branch

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
