### PR TITLE
fix(Account): do not propose SafeTx to API on a devnet

### DIFF
--- a/ape_safe/accounts.py
+++ b/ape_safe/accounts.py
@@ -867,7 +867,8 @@ class SafeAccount(AccountAPI):
             f"for Safe {self.address}#{safe_tx.nonce}"  # TODO: put URI
         )
 
-        if not self.provider.network.is_dev:
+        # NOTE: Do not publish to API on a dev network (e.g. `mainnet-fork`) unless mocked
+        if not self.provider.network.is_dev or isinstance(self.client, MockSafeClient):
             self.propose_safe_tx(
                 safe_tx,
                 submitter=submitter_account,
@@ -916,8 +917,10 @@ class SafeAccount(AccountAPI):
 
             # else: didn't want to sign
 
-        if new_signatures and not self.provider.network.is_dev:
-            self.client.post_signatures(safe_tx_id, new_signatures)
+        if new_signatures:
+            # NOTE: Do not publish to API on a dev network (e.g. `mainnet-fork`) unless mocked
+            if not self.provider.network.is_dev or isinstance(self.client, MockSafeClient):
+                self.client.post_signatures(safe_tx_id, new_signatures)
 
         # NOTE: Return all signatures, both new and existing
         return {**{c.owner: c.signature for c in confirmations}, **new_signatures}


### PR DESCRIPTION
### What I did

@milkyklim discovered this, if you are using a `-fork` network to test things out, it would still propose txns to the API if you signed them

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
