### PR TITLE
docs(Client): add note about where to get a key to error msg

### DIFF
--- a/ape_safe/client/__init__.py
+++ b/ape_safe/client/__init__.py
@@ -88,7 +88,11 @@ class SafeClient(BaseSafeClient):
                 raise ValueError(f"Chain ID {chain_id} is not a supported chain.")
 
             elif not GATEWAY_API_KEY:
-                raise ValueError("Must provide API key via 'APE_SAFE_GATEWAY_API_KEY='.")
+                raise ValueError(
+                    """Must provide API key via 'APE_SAFE_GATEWAY_API_KEY='.
+
+    Get one from https://developer.safe.global if you don't have one."""
+                )
 
             base_url = (
                 f"{SAFE_CLIENT_GATEWAY_URL}/{EIP3770_BLOCKCHAIN_NAMES_BY_CHAIN_ID[chain_id]}/api"


### PR DESCRIPTION
### What I did

tell people where to get an API key from the error message

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
