### PR TITLE
fix: support implementation as masterCopy alias

### DIFF
--- a/ape_safe/client/types.py
+++ b/ape_safe/client/types.py
@@ -57,6 +57,7 @@ class SafeDetails(BaseModel):
     owners: list[Address]
     master_copy: Address = Field(
         alias="masterCopy",
+        # NOTE: `implementation` matches an older version of the API
         validation_alias=AliasChoices("masterCopy", "implementation"),
     )
     modules: list[Address] = []


### PR DESCRIPTION
### What I did

this partially fixes safe client on fraxtal that uses `implementation` instead of `masterCopy`

fixes: #

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
