### PR TITLE
feat(CLI): execute flag

### DIFF
--- a/ape_safe/_cli/modules.py
+++ b/ape_safe/_cli/modules.py
@@ -2,7 +2,7 @@ import click
 from ape.cli import ConnectedProviderCommand, account_option, ape_cli_context
 from ape.types import AddressType
 
-from ape_safe._cli.click_ext import safe_argument
+from ape_safe.cli import execute_safetx_flag, safe_argument
 
 
 @click.group()
@@ -35,29 +35,29 @@ def guard(safe):
 @ape_cli_context()
 @account_option()
 @safe_argument
-@click.option("--propose", is_flag=True, default=False)
+@execute_safetx_flag()
 @click.argument("module")
-def enable(cli_ctx, safe, account, module, propose):
+def enable(cli_ctx, safe, account, module, execute_safetx):
     """
     Enable MODULE for SAFE
 
     **WARNING**: This is a potentially destructive action and may make your safe vulnerable.
     """
     module = cli_ctx.conversion_manager.convert(module, AddressType)
-    safe.modules.enable(module, submitter=account, propose=propose)
+    safe.modules.enable(module, submitter=account, propose=not execute_safetx)
 
 
 @modules.command(cls=ConnectedProviderCommand)
 @ape_cli_context()
 @account_option()
 @safe_argument
-@click.option("--propose", is_flag=True, default=False)
+@execute_safetx_flag()
 @click.argument("module")
-def disable(cli_ctx, safe, account, module, propose):
+def disable(cli_ctx, safe, account, module, execute_safetx):
     """
     Disable MODULE for SAFE
 
     **WARNING**: This is a potentially destructive action and may impact operations of your safe.
     """
     module = cli_ctx.conversion_manager.convert(module, AddressType)
-    safe.modules.disable(module, submitter=account, propose=propose)
+    safe.modules.disable(module, submitter=account, propose=not execute_safetx)

--- a/ape_safe/_cli/pending.py
+++ b/ape_safe/_cli/pending.py
@@ -477,7 +477,7 @@ def ensure(cli_ctx, ecosystem, network, submitter, safe):
         cli_ctx.logger.info(
             f"Running queue script for nonce {nonce} ('{script_path}'):\n\n  {cmd.help}\n"
         )
-        # NOTE: This matches signature from `ape_safe.cli:propose_batch`
+        # NOTE: This matches signature from `ape_safe.cli:batch_from_simulation`
         cmd.callback.__wrapped__.func(cli_ctx, network, submitter, nonce, safe)
 
     if not network.is_fork:

--- a/ape_safe/_cli/safe_mgmt.py
+++ b/ape_safe/_cli/safe_mgmt.py
@@ -9,7 +9,8 @@ from ape.cli import (
 from ape.exceptions import ChainError, ProviderNotConnectedError
 from eth_typing import ChecksumAddress
 
-from ape_safe._cli.click_ext import SafeCliContext, safe_argument, safe_cli_ctx
+from ape_safe._cli.click_ext import SafeCliContext, safe_cli_ctx
+from ape_safe.cli import safe_argument
 from ape_safe.client import SafeClient
 from ape_safe.exceptions import NoVersionDetected
 

--- a/ape_safe/cli.py
+++ b/ape_safe/cli.py
@@ -33,9 +33,9 @@ def execute_safetx_flag(argname: str = "execute_safetx", **option_kwargs):
     return click.option("--execute/--propose", argname, **option_kwargs)
 
 
-def propose_from_simulation():
+def batch_from_simulation():
     """
-    Create and propose a new SafeTx from transaction receipts inside a fork.
+    Create a new batch transaction from collected receipts after executing inside an isolated fork.
 
     Usage::
 
@@ -210,8 +210,12 @@ def propose_from_simulation():
     return decorator
 
 
+# TODO: Remove in v1?
+propose_from_simulation = batch_from_simulation
+
+
 __all__ = [
+    batch_from_simulation.__name__,
     execute_safetx_flag.__name__,
-    propose_from_simulation.__name__,
     safe_argument.__name__,
 ]

--- a/ape_safe/cli.py
+++ b/ape_safe/cli.py
@@ -20,6 +20,19 @@ if TYPE_CHECKING:
     from ape_safe.accounts import SafeAccount
 
 
+def execute_safetx_flag(argname: str = "execute_safetx", **option_kwargs):
+    if "help" not in option_kwargs:
+        option_kwargs["help"] = (
+            "Execute the SafeTx on-chain, or propose it to the Safe API. Defaults to proposing."
+        )
+
+    if "default" not in option_kwargs:
+        # NOTE: If overriding default, override `help=` to state what the default is too
+        option_kwargs["default"] = False
+
+    return click.option("--execute/--propose", argname, **option_kwargs)
+
+
 def propose_from_simulation():
     """
     Create and propose a new SafeTx from transaction receipts inside a fork.
@@ -85,6 +98,10 @@ def propose_from_simulation():
             "--submitter",
             prompt="Select an account to submit or propose transaction(s)",
         )
+        @execute_safetx_flag(
+            help="Execute the collected batch on-chain, or propose this transaction to the Safe API. "
+            "Defaults to proposing, unless invoked as a forked simulation.",
+        )
         @click.option(
             "--nonce",
             type=int,
@@ -97,6 +114,7 @@ def propose_from_simulation():
             cli_ctx: ApeCliContextObject,
             network: "NetworkAPI",
             submitter: "AccountAPI",
+            execute_safetx: bool,
             nonce: Optional[int],
             safe: "SafeAccount",
         ):
@@ -164,9 +182,12 @@ def propose_from_simulation():
                     nonce=nonce,
                 )
 
-            if network.is_fork:  # Testing, execute as a simulation (don't set nonce)
+            if execute_safetx:  # Execute live
+                safe.submit_safe_tx(safe_tx, submitter=submitter)
+
+            elif network.is_fork:  # Execute as a simulation (using current nonce)
                 cli_ctx.logger.info("Using fork network, dry-running SafeTx")
-                safe.create_execute_transaction(safe_tx, {}, impersonate=True, submitter=submitter)
+                safe.submit_safe_tx(safe_tx, impersonate=True, submitter=submitter)
 
             elif not (confirmations := safe.get_api_confirmations(safe_tx)):
                 # Real mainnet, propose if not already in queue
@@ -187,3 +208,10 @@ def propose_from_simulation():
         return new_cmd
 
     return decorator
+
+
+__all__ = [
+    execute_safetx_flag.__name__,
+    propose_from_simulation.__name__,
+    safe_argument.__name__,
+]


### PR DESCRIPTION
### What I did

Kind of an annoying thing, but there wasn't really a way to control whether to `execute` or `propose` a SafeTx from the `propose_from_simulation` feature (which... is probably no longer aptly named)

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
